### PR TITLE
fix(tests): use proper OS separator when loading test modules

### DIFF
--- a/config/exports/build-tests.js
+++ b/config/exports/build-tests.js
@@ -1,23 +1,30 @@
 // this script watches the tests exported by typescript, copies them to the test directories, and modifies the require("PKG.NAME") statements to test each build
 const cpx = require("cpx");
-const separator = require("path").sep;
+const isWin = /^win/.test(process.platform);
 const Transform = require("stream").Transform;
 const pkg = require('../../package');
-const req = (path) => 'require("' + path + '")';
-const pathUp = (levels) => Array.from(Array(levels), () => '../').join('');
+const req = (modulePath) => 'require("' + modulePath + '")';
+const calculatedSeparator = isWin ? '\\\\' : '/';
+const pathUp = (levels) => Array.from(Array(levels), () => '..' + calculatedSeparator).join('');
+const normalizePath = (filePath) => filePath.replace(/\//g, calculatedSeparator);
 
 // replace instances of pkg.name with the proper route to the build being tested
 const makeTransform = (filePath, buildPath) => {
-  const buildPathParts = buildPath.split(separator);
+  if (isWin) {
+    filePath = normalizePath(filePath);
+    buildPath = normalizePath(buildPath);
+  }
+
+  const buildPathParts = buildPath.split(calculatedSeparator);
   // filePath includes build/main (-2), test/BUILD is 2 deep (+2),
   // remove filename (-1). Total is length - 2
-  const pathToRoot = pathUp(filePath.split(separator).length - 1);
+  const pathToRoot = pathUp(filePath.split(calculatedSeparator).length - 1);
   const placeholder = req(pkg.name);
   return new Transform({
     transform(chunk, encoding, done) {
       const str = chunk.toString();
-      const parts = str.split(placeholder)
-      const newPath = req(pathToRoot + buildPath)
+      const parts = str.split(placeholder);
+      const newPath = req(pathToRoot + buildPath);
       const result = parts.join(newPath);
       this.push(result);
       done();

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "unit": "yarn build && yarn build:tests && nyc ava",
     "check-coverage": "nyc check-coverage --lines 100 --functions 100 --branches 100",
     "test": "yarn lint && yarn unit && yarn check-coverage",
-    "watch": "yarn build && yarn build:tests -- --no-browser && concurrently -r --kill-others 'npm run --silent build:main -- -w' 'npm run --silent build:tests -- -w --no-browser' 'sleepms 2000 && ava --watch'",
+    "watch": "yarn build && yarn build:tests -- --no-browser && concurrently -r --kill-others \"npm run --silent build:main -- -w\" \"npm run --silent build:tests -- -w --no-browser\" \"sleepms 2000 && ava --watch\"",
     "cov": "yarn unit && yarn html-coverage && opn coverage/index.html",
     "html-coverage": "nyc report --reporter=html",
     "send-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)

See bitjson/typescript-starter#18. Issue with loading `../../` style paths on Windows

* **What is the new behavior (if this is a feature change)?**

Check if Node's `process.platform` starts with `win`, then use `\\\\` separator on Windows.

* **Other information**:

I'm open to suggestions on making this change better, but WorksOnMyMachine™️ ... 👍 