### PR TITLE
Fix build-test script for windows

### DIFF
--- a/config/exports/build-tests.js
+++ b/config/exports/build-tests.js
@@ -1,25 +1,25 @@
 // this script watches the tests exported by typescript, copies them to the test directories, and modifies the require("PKG.NAME") statements to test each build
 const cpx = require("cpx");
-const separator = require("path").sep;
+const path = require("path");
 const Transform = require("stream").Transform;
 const pkg = require('../../package');
-const req = (path) => 'require("' + path + '")';
-const pathUp = (levels) => Array.from(Array(levels), () => '../').join('');
+
+const req = (path) => `require("${path}")`;
 
 // replace instances of pkg.name with the proper route to the build being tested
-const makeTransform = (filePath, buildPath) => {
-  const buildPathParts = buildPath.split(separator);
-  // filePath includes build/main (-2), test/BUILD is 2 deep (+2),
-  // remove filename (-1). Total is length - 2
-  const pathToRoot = pathUp(filePath.split(separator).length - 1);
-  const placeholder = req(pkg.name);
+const makeTransform = (rootDir, buildPath, specPath) => {
+  const specDir = path.dirname(specPath)
+  const testDir = specDir.replace(path.join(rootDir, 'build'), path.join(rootDir, 'test'))
+
+  const newRequire = path.relative(testDir, buildPath)
+    .split(path.sep).join('/')
+
   return new Transform({
     transform(chunk, encoding, done) {
-      const str = chunk.toString();
-      const parts = str.split(placeholder)
-      const newPath = req(pathToRoot + buildPath)
-      const result = parts.join(newPath);
-      this.push(result);
+      const str = chunk
+        .toString()
+        .replace(req(pkg.name), req(newRequire))
+      this.push(str);
       done();
     }
   });
@@ -31,11 +31,23 @@ const watchMode = process.argv.indexOf('-w') !== -1 ? true : false;
 const browserTests = process.argv.indexOf('--no-browser') !== -1 ? true : false;
 const task = watchMode ? cpx.watch : cpx.copy;
 
+const rootDir = path.resolve('.');
+const mainBuildPath = path.resolve(pkg.main);
+
 task(testsFromRoot, 'test/main', {
-  transform: (filePath) => makeTransform(filePath, pkg.main)
+  transform: (specPath) => makeTransform(
+    rootDir,
+    mainBuildPath,
+    path.resolve(specPath))
 });
+
 if (!browserTests) {
+  const browserBuildPath = path.resolve(pkg.browser);
+
   task(testsFromRoot, 'test/browser', {
-    transform: (filePath) => makeTransform(filePath, pkg.browser.replace('.js', '.cjs.js'))
+    transform: (specPath) => makeTransform(
+      rootDir,
+      browserBuildPath.replace('.js', '.cjs.js'),
+      path.resolve(specPath))
   });
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "unit": "yarn build && yarn build:tests && nyc ava",
     "check-coverage": "nyc check-coverage --lines 100 --functions 100 --branches 100",
     "test": "yarn lint && yarn unit && yarn check-coverage",
-    "watch": "yarn build && yarn build:tests -- --no-browser && concurrently -r --kill-others 'npm run --silent build:main -- -w' 'npm run --silent build:tests -- -w --no-browser' 'sleepms 2000 && ava --watch'",
+    "watch": "yarn build && yarn build:tests -- --no-browser && concurrently -r --kill-others \"npm run --silent build:main -- -w\" \"npm run --silent build:tests -- -w --no-browser\" \"sleepms 2000 && ava --watch\"",
     "cov": "yarn unit && yarn html-coverage && opn coverage/index.html",
     "html-coverage": "nyc report --reporter=html",
     "send-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
See #18  Issue with loading ../../ style paths on Windows


* **What is the new behavior (if this is a feature change)?**
use methods of a `path` module, to perform various operations with files and folder, instead of string.split/join

* **Other information**:
Tested on Win10 only