### PR TITLE
Make tests able to import local files

### DIFF
--- a/config/exports/build-tests.js
+++ b/config/exports/build-tests.js
@@ -9,6 +9,7 @@ const pathUp = (levels) => Array.from(Array(levels), () => '../').join('');
 // replace instances of pkg.name with the proper route to the build being tested
 const makeTransform = (filePath, buildPath) => {
   const buildPathParts = buildPath.split(separator);
+  const filePathParts = filePath.split(separator);
   // filePath includes build/main (-2), test/BUILD is 2 deep (+2),
   // remove filename (-1). Total is length - 2
   const pathToRoot = pathUp(filePath.split(separator).length - 1);
@@ -18,7 +19,9 @@ const makeTransform = (filePath, buildPath) => {
       const str = chunk.toString();
       const parts = str.split(placeholder)
       const newPath = req(pathToRoot + buildPath)
-      const result = parts.join(newPath);
+      const result = parts.join(newPath)
+      .replace(/require\(\"\.\.\//g, 'require("' + pathToRoot + filePathParts.slice(0, -2).join(separator) + separator)
+      .replace(/require\(\"\.\//g, 'require("' + pathToRoot + filePathParts.slice(0, -1).join(separator) + separator);
       this.push(result);
       done();
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix:

With this fix, the local imports in tests are resolved, and you can now do the following inside your tests;

```
import { test } from 'ava'
import { MyModule } from './myModule'
import { MyOtherModule } from '../whatever/myOtherModule'

// Use MyModule in tests
```


* **What is the current behavior?** (You can also link to an open issue here)
Currently, the tests are not able to import files locally, effectively limiting unit testing to only testing exposed code

The following does not work;
```
import { test } from 'ava'
import { MyModule } from './myModule'
import { MyOtherModule } from '../whatever/myOtherModule'

// Use MyModule in tests
```


* **What is the new behavior (if this is a feature change)?**
I consider this a bugfix.


* **Other information**:
Resolves https://github.com/bitjson/typescript-starter/issues/49