### PR TITLE
Fix failing tests on Windows

### DIFF
--- a/src/cli/tests/cli.integration.spec.ts
+++ b/src/cli/tests/cli.integration.spec.ts
@@ -108,14 +108,19 @@ async function hashAllTheThings(
   const hashes = await Promise.all(hashAll);
   return hashes.reduce<{ readonly [filename: string]: string }>(
     (acc, hash, i) => {
-      const trimmedFilePath = relative(buildDir, filePaths[i]);
+      const trimmedNormalizedFilePath = normalizePath(relative(buildDir, filePaths[i]));
       return {
         ...acc,
-        [trimmedFilePath]: hash
+        [trimmedNormalizedFilePath]: hash
       };
     },
     {}
   );
+}
+
+// On Windows, convert backslashes to forward slashes
+function normalizePath(p: string) {
+  return process.platform === 'win32' ? p.replace(/\\/g, '/') : p;
 }
 
 test(`${


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Tests fail on Windows.

* **What is the new behavior (if this is a feature change)?**

Tests pass on Windows. (not completely; see below)

* **Other information**:

`hashAllTheThings` used to return paths with native separators, which did not match the hard-coded posix-style paths elsewhere in the tests.

Tests still do not completely pass because the latest version of execa is using an outdated version of cross-spawn with a bug.  They've merged a PR to upgrade but haven't published it to NPM yet.  https://github.com/sindresorhus/execa/issues/131