### PR TITLE
Add '.idea/*' to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 build
 test
 src/**.js
+.idea/*
 
 coverage
 .nyc_output


### PR DESCRIPTION
This PR adds `.idea/*` to the `.gitignore` files, useful when using IntelliJ/Webstorm IDEs