### PR TITLE
feat(vscode): add Debug Spec to debug .spec.ts files directly

### DIFF
--- a/.vscode/debug-ts.js
+++ b/.vscode/debug-ts.js
@@ -1,0 +1,52 @@
+'use strict';
+const meow = require('meow');
+const path = require('path');
+
+const tsFile = getTSFile();
+const jsFile = TS2JS(tsFile);
+
+replaceCLIArg(tsFile, jsFile);
+
+// Ava debugger
+require('ava/profile');
+
+/**
+ * get ts file path from CLI args
+ *
+ * @return string path
+ */
+function getTSFile() {
+  const cli = meow();
+  return cli.input[0];
+}
+
+/**
+ * get associated compiled js file path
+ *
+ * @param tsFile  path
+ * @return string path
+ */
+function TS2JS(tsFile) {
+  const srcFolder = path.join(__dirname, '..', 'src');
+  const distFolder = path.join(__dirname, '..', 'build', 'main');
+
+  const tsPathObj = path.parse(tsFile);
+
+  return path.format({
+    dir: tsPathObj.dir.replace(srcFolder, distFolder),
+    ext: '.js',
+    name: tsPathObj.name,
+    root: tsPathObj.root
+  });
+}
+
+/**
+ * replace a value in CLI args
+ *
+ * @param search  value to search
+ * @param replace  value to replace
+ * @return void
+ */
+function replaceCLIArg(search, replace) {
+  process.argv[process.argv.indexOf(search)] = replace;
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,6 @@
 {
   "version": "0.2.0",
-  "configurations": [
-    {
+  "configurations": [{
       "type": "node",
       "request": "launch",
       "name": "Debug Project",
@@ -26,22 +25,11 @@
       "console": "externalTerminal"
     },
     {
-      /// Usage: set appropriate breakpoints in a *.spec.ts file, then open the
-      // respective *.spec.js file to run this task. Once a breakpoint is hit,
-      // the debugger will open the source *.spec.ts file for debugging.
       "type": "node",
       "request": "launch",
-      "name": "Debug Visible Compiled Spec",
-      "program": "${workspaceFolder}/node_modules/ava/profile.js",
-      "args": [
-        "${file}"
-        // TODO: VSCode's launch.json variable substitution
-        // (https://code.visualstudio.com/docs/editor/variables-reference)
-        // doesn't quite allow us to go from:
-        // `./src/path/to/file.ts` to `./build/main/path/to/file.js`
-        // so the user has to navigate to the compiled file manually. (Close:)
-        // "${workspaceFolder}/build/main/lib/${fileBasenameNoExtension}.js"
-      ],
+      "name": "Debug Spec",
+      "program": "${workspaceRoot}/.vscode/debug-ts.js",
+      "args": ["${file}"],
       "skipFiles": ["<node_internals>/**/*.js"],
       // Consider using `npm run watch` or `yarn watch` for faster debugging
       // "preLaunchTask": "npm: build",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
VSCode debug spec feature


* **What is the current behavior?** (You can also link to an open issue here)
we currently need to go to the compiled .spec.js file to launch the debugger 


* **What is the new behavior (if this is a feature change)?**
go to your .spec.ts file add some breakpoints and launch Debug Spec


* **Other information**:
