### PR TITLE
fix(test): fix generic type Maco requires arguments

### DIFF
--- a/src/lib/hash.spec.ts
+++ b/src/lib/hash.spec.ts
@@ -2,7 +2,7 @@
 import test, { Macro } from 'ava';
 import { sha256, sha256Native } from './hash';
 
-const hash: Macro = (t, input: string, expected: string) => {
+const hash: Macro<[string, string]> = (t, input: string, expected: string) => {
   t.is(sha256(input), expected);
   t.is(sha256Native(input), expected);
 };


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
* **What is the current behavior?** (You can also link to an open issue here)
Refer to [ISSUE-154](https://github.com/bitjson/typescript-starter/issues/154)

* **What is the new behavior (if this is a feature change)?**
Passed `yarn watch` without `error TS2707: Generic type 'Macro<Args, Context>' requires between 1 and 2 type arguments`

* **Other information**:
None