### PR TITLE
Fix a typo that was causing missing dependency in build output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.4.6](https://github.com/bitjson/typescript-starter/compare/v2.4.5...v2.4.6) (2019-09-07)
+
+
+
 ### [2.4.5](https://github.com/bitjson/typescript-starter/compare/v2.4.4...v2.4.5) (2019-07-10)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-starter",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-starter",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "A typescript starter for building javascript libraries and projects",
   "bin": {
     "typescript-starter": "./bin/typescript-starter"

--- a/src/cli/typescript-starter.ts
+++ b/src/cli/typescript-starter.ts
@@ -55,7 +55,7 @@ export async function typescriptStarter(
     'npm-scripts-info',
     '@bitjson/npm-scripts-info',
     'nyc',
-    'opn-cli',
+    'open-cli',
     'prettier',
     'standard-version',
     'trash-cli',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This change is a bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

The built output is missing a dev dependency (open-cli) because of this typo (opn-cli). In the built output, 'yarn build' and 'yarn test' work but 'yarn cov' and 'yarn doc' fail without open-cli present.

* **What is the new behavior (if this is a feature change)?**

This fixes the missing dependency and allows all the scripts in package.json to run without errors.

