### PR TITLE
Fix link to config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The interactive CLI will help you create and configure your project automaticall
 * Export as a [javascript module](http://jsmodules.io/), making your work **fully tree-shakable** for consumers capable of using [es6 imports](https://github.com/rollup/rollup/wiki/pkg.module) (like [Rollup](http://rollupjs.org/), [Webpack](https://webpack.js.org/), or [Parcel](https://parceljs.org/))
 * Export type declarations to improve your downstream development experience
 * Backwards compatibility for Node.js-style (CommonJS) imports
-* Both strict and flexible [typescript configurations](config/tsconfig.json) available
+* Both strict and flexible [typescript configurations](./tsconfig.json) available
 
 So we can have nice things:
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It fixes a broken link in the readme.

* **What is the current behavior?** (You can also link to an open issue here)

The link in

> Both strict and flexible [typescript configurations](https://github.com/bitjson/typescript-starter/blob/master/config/tsconfig.json) available

no longer points to an existing file.

* **What is the new behavior (if this is a feature change)?**

The link points to an existing file.

* **Other information**:

Nope.