### PR TITLE
chore(deps): Upgrade to modern typedoc@0.22.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,8 +112,8 @@
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "standard-version": "^9.0.0",
-    "ts-node": "^9.0.0",
-    "typedoc": "^0.19.0",
+    "ts-node": "^10.4.0",
+    "typedoc": "~0.22.10",
     "typescript": "^4.0.2"
   },
   "files": [


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Typedoc 0.22 offers several features over 0.19. Also the esily accessible documentation is all for 0.22.
